### PR TITLE
Modification of readTree and writeTree methods to preserve node labels during conversion between 'phylo' and 'TreeMan' classes.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: treeman
 Type: Package
 Title: Phylogenetic Tree Manipulation Class and Methods
-Version: 1.1.4
+Version: 1.1.5
 Author: D.J. Bennett
 Maintainer: D.J. Bennett <dominic.john.bennett@gmail.com>
 Description: S4 class and methods for intuitive and efficient phylogenetic tree manipulation.

--- a/R/cnvrt-methods.R
+++ b/R/cnvrt-methods.R
@@ -16,7 +16,7 @@ setOldClass('multiPhylo')
 
 #' @name TreeMan-to-phylo
 #' @title Convert TreeMan to phylo
-#' @description Return ape's \code{phylo} from a \code{TreeMan}
+#' @description Return ape's \code{phylo} from a \code{TreeMan}. This will preserve node labels if they are different from the default labels (n#).
 #' @seealso 
 #' \code{\link{phylo-to-TreeMan}},
 #' \code{\link{TreeMen-to-multiPhylo}}
@@ -37,7 +37,8 @@ setAs(from="phylo", to="TreeMan", def=function(from, to) {
 
 #' @name phylo-to-TreeMan
 #' @title Convert phylo to TreeMan
-#' @description Return a \code{TreeMan} from ape's \code{phylo}
+#' @description Return a \code{TreeMan} from ape's \code{phylo}. This will preserve node labels, if they are a alphanumeric.
+
 #' @seealso
 #' \code{\link{TreeMan-to-phylo}},
 #' \code{\link{TreeMen-to-multiPhylo}}

--- a/R/cnvrt-methods.R
+++ b/R/cnvrt-methods.R
@@ -56,10 +56,10 @@ setAs(from="TreeMan", to="phylo", def=function(from, to) {
   if (all(from["nds"] == paste0("n", seq_along(from["nds"])))) {
     node_labeller <- function(nd) { return(NULL) } # no node labels 
   } else {
-    node_labeller <- function(n) { print(n); n[['id']] } # writes node labels 
+    nodeLabeller <- function(n) { n[['id']] } # writes node labels 
   }
 
-  writeTree(from, file=temp_file, ndLabels = node_labeller)
+  writeTree(from, file=temp_file, ndLabels = nodeLabeller)
   tree <- ape::read.tree(file=temp_file)
   file.remove(temp_file)
   return(tree)

--- a/R/cnvrt-methods.R
+++ b/R/cnvrt-methods.R
@@ -50,7 +50,16 @@ setAs(from="phylo", to="TreeMan", def=function(from, to) {
 #' tree <- as(tree, 'TreeMan')
 setAs(from="TreeMan", to="phylo", def=function(from, to) {
   temp_file <- tempfile(pattern="temp_tree", fileext=".tre")
-  writeTree(from, file=temp_file)
+  
+  # use a node label function function that writes the node labels during the 
+  # conversion, if they are non default.
+  if (all(from["nds"] == paste0("n", seq_along(from["nds"])))) {
+    node_labeller <- function(nd) { return(NULL) } # no node labels 
+  } else {
+    node_labeller <- function(n) { print(n); n[['id']] } # writes node labels 
+  }
+
+  writeTree(from, file=temp_file, ndLabels = node_labeller)
   tree <- ape::read.tree(file=temp_file)
   file.remove(temp_file)
   return(tree)

--- a/R/read-write-methods.R
+++ b/R/read-write-methods.R
@@ -199,7 +199,10 @@ readTree <- function(file=NULL, text=NULL, spcl_slt_nm='Unknown', wndmtrx=FALSE,
   other <- rep(NA, length(ids))
   intnds <- 1:length(ids) %in% prinds
   other[intnds] <- ids[intnds]
-  ids[intnds] <- paste0('n', which(intnds))
+  # overwrite internal node ids only if at least one is malformed
+  if (any(grepl('[^a-zA-Z_0-9]', ids[intnds]))){
+    ids[intnds] <- paste0('n', which(intnds))
+  }
   # rm NAs from IDs
   pull <- is.na(ids)
   ids[pull] <- paste0('n', which(pull))

--- a/R/read-write-methods.R
+++ b/R/read-write-methods.R
@@ -202,6 +202,9 @@ readTree <- function(file=NULL, text=NULL, spcl_slt_nm='Unknown', wndmtrx=FALSE,
   # overwrite internal node ids only if at least one is malformed
   if (any(grepl('[^a-zA-Z_0-9]', ids[intnds]))){
     ids[intnds] <- paste0('n', which(intnds))
+  } else {
+      # if using internal node ids as ids, no need for special slot
+      other[intnds] <- NA
   }
   # rm NAs from IDs
   pull <- is.na(ids)

--- a/tests/testthat/test-cnvrt-methods.R
+++ b/tests/testthat/test-cnvrt-methods.R
@@ -14,6 +14,20 @@ test_that('phylo-to-TreeMan works', {
   tree <- as(tree, "TreeMan")
   expect_equal(class(tree)[1], "TreeMan")
 })
+test_that('phylo-to-TreeMan works w/ node labels', {
+  tree <- ape::rtree(100)
+  tree$node.label <- paste0("Node", seq_len(tree$Nnode))
+  tree_tm <- as(tree, "TreeMan")
+  expect_equal(class(tree_tm)[1], "TreeMan")
+  expect_true(all(tree_tm["nds"] %in% tree$node.label))
+})
+test_that('phylo-to-TreeMan-to-phylo works w/ node labels', {
+  tree <- ape::rtree(100)
+  tree$node.label <- paste0("Node", seq_len(tree$Nnode))
+  tree_cnvrt <- as(as(tree, "TreeMan"), "phylo")
+  expect_equal(class(tree)[1], "phylo")
+  expect_equal(tree, tree_cnvrt)
+})
 test_that('multiPhylo-to-TreeMen works', {
   trees <- c(ape::rtree(100), ape::rtree(100), ape::rtree(100))
   trees <- as(trees, "TreeMen")

--- a/tests/testthat/test-rw-methods.R
+++ b/tests/testthat/test-rw-methods.R
@@ -25,11 +25,19 @@ test_that('readTree([w/o spans]) works', {
   expect_that(tree['ntips'], equals(4))
   expect_false(tree['wspn'])
 })
-test_that('readTree([w/ node labels]) works', {
+test_that('readTree([w/ malformed node labels]) works', {
   text <- "(A,B,(C,D)0.9)0.8;"
   tree <- readTree(text=text, spcl_slt_nm='bootstrap',
                    wndmtrx=sample(c(TRUE, FALSE), 1))
   expect_that(tree['ntips'], equals(4))
+  expect_false(tree['wspn'])
+})
+test_that('readTree([w/ node labels]) works', {
+  text <- "(A,B,(C,D)N1)N2;"
+  tree <- readTree(text=text, spcl_slt_nm='bootstrap',
+                   wndmtrx=sample(c(TRUE, FALSE), 1))
+  expect_that(tree['ntips'], equals(4))
+  expect_that(tree['nds'], equals(c("N1","N2")))
   expect_false(tree['wspn'])
 })
 test_that('writeTree() works', {

--- a/tests/testthat/test-rw-methods.R
+++ b/tests/testthat/test-rw-methods.R
@@ -25,10 +25,19 @@ test_that('readTree([w/o spans]) works', {
   expect_that(tree['ntips'], equals(4))
   expect_false(tree['wspn'])
 })
-test_that('readTree([w/ malformed node labels]) works', {
+test_that('readTree([w/ special node slot]) works', {
   text <- "(A,B,(C,D)0.9)0.8;"
   tree <- readTree(text=text, spcl_slt_nm='bootstrap',
                    wndmtrx=sample(c(TRUE, FALSE), 1))
+  slt_bs <- getNdsSlt(tree = tree, slt_nm = 'bootstrap', ids = tree['nds'])
+  expect_true(all(c('0.9', '0.8') %in% slt_bs))
+  expect_equal(tree['othr_slt_nms'], 'bootstrap')
+  expect_that(tree['ntips'], equals(4))
+  expect_false(tree['wspn'])
+})
+test_that('readTree([w/ non-standard node labels]) works', {
+  text <- "(A,B,(C,D)%N1)!N2;"
+  tree <- readTree(text=text)
   expect_that(tree['ntips'], equals(4))
   expect_false(tree['wspn'])
 })


### PR DESCRIPTION
Please see descriptions in the commit messages for details.